### PR TITLE
Should fix Option program must be a kind of [String]!  You passed true.

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -30,7 +30,7 @@ attribute :chroot,      :kind_of => String, :default => nil
 attribute :chdir,       :kind_of => String, :default => nil
 attribute :nice,        :kind_of => String, :default => nil
 attribute :prestart,    :kind_of => String, :default => nil
-attribute :program,     :kind_of => String, :default => true
+attribute :program,     :kind_of => String, :default => nil
 attribute :args,        :kind_of => Array,  :default => ['']
 attribute :platform,    :kind_of => String, :default => node['pleaserun']['platform']
 attribute :target_version, :kind_of => String, :default => node['pleaserun']['target_version']


### PR DESCRIPTION
Getting this error:

```
================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/pleaserun/resources/default.rb
================================================================================
Chef::Exceptions::ValidationFailed
----------------------------------
Option program must be a kind of [String]!  You passed true.
Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/pleaserun/resources/default.rb:33:in `class_from_file'
Relevant File Content:
----------------------
/var/chef/cache/cookbooks/pleaserun/resources/default.rb:
 26:  attribute :description, :kind_of => String, :default => nil
 27:  attribute :umask,       :kind_of => String, :default => nil
 28:  attribute :runas,       :kind_of => String, :default => nil
 29:  attribute :chroot,      :kind_of => String, :default => nil
 30:  attribute :chdir,       :kind_of => String, :default => nil
 31:  attribute :nice,        :kind_of => String, :default => nil
 32:  attribute :prestart,    :kind_of => String, :default => nil
 33>> attribute :program,     :kind_of => String, :default => true
 34:  attribute :args,        :kind_of => Array,  :default => ['']
 35:  attribute :platform,    :kind_of => String, :default => node['pleaserun']['platform']
 36:  attribute :target_version, :kind_of => String, :default => node['pleaserun']['target_version']
```