### PR TITLE
fix default attrs, gem loading and compatibility for darwin/freebsd

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -76,7 +76,6 @@ end
 def write_file(path,content,perms)
   file path do
     owner 'root'
-    group 'root'
     mode  '0700'
     content content
     action :create

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,6 +8,5 @@
 
 chef_gem 'pleaserun' do
   compile_time true if respond_to?(:compile_time)
-  clear_sources true
 end
 require  'pleaserun/namespace'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,5 +6,8 @@
 # Copyright 2014, Paul Czarkowski, Rackspace
 #
 
-chef_gem 'pleaserun'
+chef_gem 'pleaserun' do
+  compile_time true if respond_to?(:compile_time)
+  clear_sources true
+end
 require  'pleaserun/namespace'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -30,7 +30,7 @@ attribute :chroot,      :kind_of => String, :default => nil
 attribute :chdir,       :kind_of => String, :default => nil
 attribute :nice,        :kind_of => String, :default => nil
 attribute :prestart,    :kind_of => String, :default => nil
-attribute :program,     :kind_of => String, :default => true
+attribute :program,     :kind_of => String, :default => nil
 attribute :args,        :kind_of => Array,  :default => ['']
 attribute :platform,    :kind_of => String, :default => node['pleaserun']['platform']
 attribute :target_version, :kind_of => String, :default => node['pleaserun']['target_version']


### PR DESCRIPTION
## Problem
* Default for program attribute in resource defaults to boolean which is incompatible with specified type
* pleaserun gem is not being initialized at start of chef-client run
* pleaserun fails on darwin and freebsd based systems since there is no root group

## Solution
* Implement work from @allaire on fixing default type
* Specify compile_time for chef_gem
* Remove specifying group for generated file